### PR TITLE
fix any_guard to work after closed permitted guards

### DIFF
--- a/guards/builtins/all_guards.py
+++ b/guards/builtins/all_guards.py
@@ -15,9 +15,8 @@ class AllGuards(GuardContainer):
         if self.short_circuit and not guard.permitted and guard.closed:
             self.closed = True
 
-    def run(self, event, *args, **kwargs):
+    def _before_run(self):
         self.permitted = True
-        super().run(event, *args, **kwargs)
 
 
 def all_guards(*guard_constructors: Type[Guard], short_circuit=True):

--- a/guards/builtins/any_guard.py
+++ b/guards/builtins/any_guard.py
@@ -15,9 +15,8 @@ class AnyGuard(GuardContainer):
         if self.short_circuit and guard.permitted and guard.closed:
             self.closed = True
 
-    def run(self, event, *args, **kwargs):
+    def _before_run(self):
         self.permitted = False
-        super().run(event, *args, **kwargs)
 
 
 def any_guard(*guard_constructors: Type[Guard], short_circuit=True):

--- a/guards/builtins/guard_container.py
+++ b/guards/builtins/guard_container.py
@@ -38,6 +38,9 @@ class GuardContainer(Guard):
             guard.run(*args, **kwargs)
             self.effective_guard = guard
 
+    def _before_run(self):
+        pass
+
     def run(self, event, *args, **kwargs):
         if self.closed:
             return
@@ -46,6 +49,11 @@ class GuardContainer(Guard):
 
         closed_guards = []
         listeners = self.listener_map.get(event, [])
+        if len(listeners) == 0:
+            return
+
+        self._before_run()
+
         for guard in listeners:
             self._run_guard(guard, event, *args, **kwargs)
             if self.closed:

--- a/guards/builtins/tests/test_all_guards.py
+++ b/guards/builtins/tests/test_all_guards.py
@@ -44,6 +44,15 @@ class TestAllGuards:
 
         assert not all_guards_instance.permitted
 
+    def test_not_permitted_on_rerun_after_closed(self):
+        self.guard_1.permitted = False
+        self.guard_1.test_next_closed = True
+        all_guards_instance = all_guards(lambda: self.guard_1)()
+        all_guards_instance.run(RUN_EVENT)
+        all_guards_instance.run(RUN_EVENT)
+
+        assert not all_guards_instance.permitted
+
     def test_permitted_if_all_permitted(self):
         self.guard_2.permitted = True
         all_guards_instance = all_guards(lambda: self.guard_1, lambda: self.guard_2)()

--- a/guards/builtins/tests/test_any_guard.py
+++ b/guards/builtins/tests/test_any_guard.py
@@ -44,6 +44,15 @@ class TestAnyGuard:
 
         assert any_guard_instance.permitted
 
+    def test_permitted_on_rerun_if_all_closed(self):
+        self.guard_1.test_next_closed = True
+
+        any_guard_instance = any_guard(lambda: self.guard_1)()
+        any_guard_instance.run(RUN_EVENT)
+        any_guard_instance.run(RUN_EVENT)
+
+        assert any_guard_instance.permitted
+
     def test_not_permitted_if_none_permitted(self):
         self.guard_1.permitted = False
         self.guard_1.test_next_closed = True

--- a/guards/context/context.py
+++ b/guards/context/context.py
@@ -15,6 +15,10 @@ class GuardContext:
         self.guards: GuardManager = GuardManager()
         self.closed = False
 
+    @property
+    def running(self):
+        return self.guards.running
+
     def add_guard(self, guard_constructor: Callable[[], Guard]):
         self.guards.add(guard_constructor())
 

--- a/guards/context/tests/test_context.py
+++ b/guards/context/tests/test_context.py
@@ -16,6 +16,11 @@ def build_fake_guard_manager():
         test_adds = []
         test_runs = []
         test_closed = False
+        test_running = False
+
+        @property
+        def running(self):
+            return FakeGuardManager.test_running
 
         def add(self, guard):
             FakeGuardManager.test_adds.append(guard)
@@ -57,6 +62,13 @@ class TestGuardContext:
 
         assert len(self.FakeGuardManager.test_runs) == 1
         assert self.FakeGuardManager.test_runs[0] == RUN_EVENT
+
+    def test_running_is_called_over(self):
+        self.FakeGuardManager.test_running = False
+        assert not self.context.running
+
+        self.FakeGuardManager.test_running = True
+        assert self.context.running
 
     def test_emit_calls_run(self):
         self.context.emit(GuardEventKey(TEST_EVENT))

--- a/guards/core/tests/test_guard_manager.py
+++ b/guards/core/tests/test_guard_manager.py
@@ -44,6 +44,24 @@ class TestGuardManager:
 
         assert len(self.guard.test_runs) == 1
 
+    def test_running_gets_set_properly(self):
+        class TestGuard(FakeGuard):
+            def run(self, *args, **kwargs):
+                assert self.guard_manager.running
+                raise Exception("To test finally")
+
+        self.guard_manager.add(TestGuard())
+
+        assert not self.guard_manager.running
+
+        try:
+            self.guard_manager.run()
+        except Exception:
+            pass
+        assert not self.guard_manager.running
+
+        assert not self.guard_manager.running
+
     def test_runs_open_guard_multiple_times(self):
         self.guard.permitted = True
         self.guard.closed = False


### PR DESCRIPTION
**Scope:**
 - If you have guards that are permitted and closed in an `any_guard`, and you run the `any_guard` again, it will fail even though all of its guards are permitted.
 - `any_guard` internally sets `permitted` to `False` before every `run`, and if any of its ran guard is permitted, it will set its `permitted` to `True`, making an or logic.
 - If all guards are closed, none of them will be ran, so `permitted` becomes `False`, and there is nothing to set it back to true.

**Development:**
 - Modified `run` of `AnyGuard` to remember the previous value of `permitted`, and set it to `None` instead of `False` initially
 - If none of the guards ran, it can be known that the permitted is not `False`, but `None`, so we can restore the previous `permitted`