### PR TITLE
Fix closed guards

### DIFF
--- a/guards/builtins/guard_container.py
+++ b/guards/builtins/guard_container.py
@@ -45,8 +45,6 @@ class GuardContainer(Guard):
         if self.closed:
             return
 
-        any_open = False
-
         closed_guards = []
         listeners = self.listener_map.get(event, [])
         if len(listeners) == 0:
@@ -61,13 +59,11 @@ class GuardContainer(Guard):
 
             if guard.closed:
                 closed_guards.append(guard)
-            else:
-                any_open = True
 
         for closed_guard in closed_guards:
             listeners.remove(closed_guard)
 
-        self.closed = not any_open
+        self.closed = all([guard.closed for guard in self.guards])
 
     def get_effective_guard(self):
         if self.effective_guard:

--- a/guards/builtins/tests/test_guard_container.py
+++ b/guards/builtins/tests/test_guard_container.py
@@ -101,6 +101,17 @@ class TestGuardContainer:
 
         assert self.guard_container.closed
 
+    def test_stays_open_if_guards_in_current_listener_get_closed(self):
+        self.guard_1.test_next_closed = True
+        self.guard_2.listens_on = [TEST_EVENT_2]
+
+        self.guard_container.add(self.guard_1)
+        self.guard_container.add(self.guard_2)
+
+        self.guard_container.run(RUN_EVENT)
+
+        assert not self.guard_container.closed
+
     def test_returns_last_runned_guard_as_effective_guard(self):
         self.guard_container.add(self.guard_1)
 


### PR DESCRIPTION
**Scope:**

Currently an error causes an issue with guard containers, so with `any_guard` and `all_guards`.

When a guard container contains a guard listening on RUN_EVENT, and another guard listening on custom event, if the first guard closes, the whole guard container will be closed. This is because currently we make the guard containers closed when all the guards in the current listener map get closed, but we should test if all guards are closed in the whole guard container

**Development:**

Fixed this issue by making it close when all the guards are closed in the whole guard container.