### PR TITLE
fix(guards/builtins) Fixing guard container to always consider all guards calculating permitted

### DIFF
--- a/guards/builtins/all_guards.py
+++ b/guards/builtins/all_guards.py
@@ -10,13 +10,14 @@ class AllGuards(GuardContainer):
 
     def _run_guard(self, guard, *args, **kwargs):
         super()._run_guard(guard, *args, **kwargs)
-        if not guard.permitted:
-            self.permitted = False
         if self.short_circuit and not guard.permitted and guard.closed:
+            self.permitted = False
             self.closed = True
 
-    def _before_run(self):
-        self.permitted = True
+    def run(self, event, *args, **kwargs):
+        super().run(event, *args, **kwargs)
+
+        self.permitted = all([guard.permitted for guard in self.guards])
 
 
 def all_guards(*guard_constructors: Type[Guard], short_circuit=True):

--- a/guards/builtins/any_guard.py
+++ b/guards/builtins/any_guard.py
@@ -10,13 +10,14 @@ class AnyGuard(GuardContainer):
 
     def _run_guard(self, guard, *args, **kwargs):
         super()._run_guard(guard, *args, **kwargs)
-        if guard.permitted:
-            self.permitted = True
         if self.short_circuit and guard.permitted and guard.closed:
+            self.permitted = True
             self.closed = True
 
-    def _before_run(self):
-        self.permitted = False
+    def run(self, event, *args, **kwargs):
+        super().run(event, *args, **kwargs)
+
+        self.permitted = any([guard.permitted for guard in self.guards])
 
 
 def any_guard(*guard_constructors: Type[Guard], short_circuit=True):

--- a/guards/builtins/guard_container.py
+++ b/guards/builtins/guard_container.py
@@ -38,9 +38,6 @@ class GuardContainer(Guard):
             guard.run(*args, **kwargs)
             self.effective_guard = guard
 
-    def _before_run(self):
-        pass
-
     def run(self, event, *args, **kwargs):
         if self.closed:
             return
@@ -49,8 +46,6 @@ class GuardContainer(Guard):
         listeners = self.listener_map.get(event, [])
         if len(listeners) == 0:
             return
-
-        self._before_run()
 
         for guard in listeners:
             self._run_guard(guard, event, *args, **kwargs)

--- a/guards/builtins/tests/test_all_guards.py
+++ b/guards/builtins/tests/test_all_guards.py
@@ -53,6 +53,22 @@ class TestAllGuards:
 
         assert not all_guards_instance.permitted
 
+    def test_stays_non_permitted_on_later_events(self):
+        TEST_EVENT = "test-event"
+
+        self.guard_1.permitted = False
+        self.guard_1.test_next_closed = False
+
+        self.guard_2.permitted = True
+        self.guard_2.listens_on = [TEST_EVENT]
+        self.guard_2.test_next_closed = False
+
+        any_guard_instance = all_guards(lambda: self.guard_1, lambda: self.guard_2)()
+        any_guard_instance.run(RUN_EVENT)
+        any_guard_instance.run(TEST_EVENT)
+
+        assert not any_guard_instance.permitted
+
     def test_permitted_if_all_permitted(self):
         self.guard_2.permitted = True
         all_guards_instance = all_guards(lambda: self.guard_1, lambda: self.guard_2)()

--- a/guards/builtins/tests/test_any_guard.py
+++ b/guards/builtins/tests/test_any_guard.py
@@ -64,6 +64,22 @@ class TestAnyGuard:
 
         assert not any_guard_instance.permitted
 
+    def test_stays_permitted_on_later_events(self):
+        TEST_EVENT = "test-event"
+
+        self.guard_1.permitted = True
+        self.guard_1.test_next_closed = False
+
+        self.guard_2.permitted = False
+        self.guard_2.listens_on = [TEST_EVENT]
+        self.guard_2.test_next_closed = False
+
+        any_guard_instance = any_guard(lambda: self.guard_1, lambda: self.guard_2)()
+        any_guard_instance.run(RUN_EVENT)
+        any_guard_instance.run(TEST_EVENT)
+
+        assert any_guard_instance.permitted
+
     def test_short_circuit(self):
         self.guard_1.test_next_closed = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [project]
 name = "guards"
-version = "0.0.1"
+version = "0.0.2"
 author ="Alias Innovations"
 description = "A package to ensure restrictions in form of guards in an application"
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="guards",
-    version="0.0.1",
+    version="0.0.2",
     author="Alias Innovations",
     author_email="",
     description="A package to ensure restrictions in form of guards in an application",


### PR DESCRIPTION
    Scope:
     - Checking if the guard container was permitted was decided by setting the `permitted` to a value, and changing it on a guard run.
     - I.e. with `any_guard`, before running the guards, the container's `permitted` is set to `False`, then the guards are ran, and if any of the nested guards is permitting, it is set to permitting
     - The issue is when guard 1 permits, and is ran on `EVENT_1`, and guard 2 does not permit and is ran on `EVENT_2`, and `EVENT_2` happens after `EVENT_1`. The permitting state of guard 1 is overwritten by the `before_run` of `EVENT_2`
    
    Development:
     - Removed `_before_run` hook from guard container as it is no longer needed
     - Added logic to `any_guard` and `all_guards` to consider every guard in them after all event.
    
    Steps to reproduce:
     - See the new test cases
